### PR TITLE
fixed navbar color on media query 992px+ screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -189,6 +189,7 @@ img::-moz-selection {
     margin-bottom: 5px;
   }
 }
+
 #mainNav .navbar-toggler {
   font-size: 12px;
   right: 0;
@@ -237,6 +238,7 @@ img::-moz-selection {
     transition: padding-top 0.3s, padding-bottom 0.3s;
     border: none;
     background-color: transparent;
+    background-color: #323033;
   }
   #mainNav .navbar-brand {
     font-size: 1.75em;


### PR DESCRIPTION
The previous color was abstracting view from the navbar options. none of them could be seen. Changed color to match the theme.